### PR TITLE
Added the pipe (%>%) to fn_regex()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -276,7 +276,11 @@ tbls_identical <- function(subtbl,
 #' @return a string containing a regular expression
 #' @export
 fn_regex <- function(fname) {
-  paste0("(^|[^[:alnum:]_])*(", fname, ")[[:space:]]*\\(")
+  if (fname == "%>%") {
+    "%>%" # match the pipe
+  } else {
+    paste0("(^|[^[:alnum:]_])*(", fname, ")[[:space:]]*\\(")
+  }
 }
 
 #' Test whether code includes a function


### PR DESCRIPTION
Added the pipe (`%>%`) to `fn_regex()` so it can be detected in `code_includes()`

Otherwise, fn_regex looks for `%>%(`

Alternatively, you could add an argument to `code_includes()` that you want to use your own regex (not the `fn_regex()` output)? This would be more flexible and still work fine with something like `code_includes("%>%", ._ac, regex = TRUE)`